### PR TITLE
Dynamic TLD list and extra Error checking

### DIFF
--- a/components/modules/domainnameapi/domainnameapi.php
+++ b/components/modules/domainnameapi/domainnameapi.php
@@ -1557,12 +1557,23 @@ class Domainnameapi extends RegistrarModule
     /**
      * Get a list of the TLDs supported by the registrar module
      *
-     * @param int $module_row_id The ID of the module row to fetch for the current module
+     * @param int|null $module_row_id The ID of the module row to fetch for the current module
      * @return array A list of all TLDs supported by the registrar module
      */
     public function getTlds($module_row_id = null)
     {
-        return Configure::get('Domainnameapi.tlds');
+        $row = $this->getModuleRow($module_row_id);
+        $row = !empty($row) ? $row : $this->getModuleRows()[0];
+        $api = $this->getApi($row->meta->user, $row->meta->key);
+
+        $all_tlds = $api->GetTldList(1000);
+        $response = [];
+        if ($all_tlds["result"] == "OK") {
+            foreach ($all_tlds["data"] as $k => $v) {
+                array_push($response, "." . $v["tld"]);
+            }
+        }
+        return $response;
     }
 
 

--- a/components/modules/domainnameapi/domainnameapi.php
+++ b/components/modules/domainnameapi/domainnameapi.php
@@ -1534,23 +1534,23 @@ class Domainnameapi extends RegistrarModule
 
 
         $response = [];
-
-        if ($all_tlds['result'] == 'OK') {
-            foreach ($all_tlds['data'] as $k => $v) {
+        $invalids = [];
+        if ($all_tlds["result"] == "OK") {
+            foreach ($all_tlds["data"] as $k => $v) {
                 foreach (range($v['minperiod'], $v['maxperiod']) as $ky => $vy) {
-                    $response['.' . $v['tld']]['USD'][$vy]['register'] = number_format($v['pricing']['registration'][1] * $vy,3);
-                    $response['.' . $v['tld']]['USD'][$vy]['transfer'] = number_format($v['pricing']['transfer'][1] * $vy,3);
-                    $response['.' . $v['tld']]['USD'][$vy]['renew']    = number_format($v['pricing']['renew'][1] * $vy,3);
+                    try {
+                        $response['.' . $v['tld']]['USD'][$vy]['register'] = number_format($v['pricing']['registration'][1] * $vy,3);
+                        $response['.' . $v['tld']]['USD'][$vy]['transfer'] = number_format($v['pricing']['transfer'][1] * $vy,3);
+                        $response['.' . $v['tld']]['USD'][$vy]['renew']    = number_format($v['pricing']['renew'][1] * $vy,3);
+                    } catch (Exception $e) {
+                        $invalids[$v["tld"]] = $v;
+                    }
                 }
             }
         }
-
-
-
-
-
-
-
+        if (!empty($invalids)) {
+            $this->log($api->getServiceUrl() . "|" . "getFilteredTldPricing",json_encode($invalids, true),"input",false);
+        }
         return $response;
     }
 


### PR DESCRIPTION
Instead of using the hard-coded TLD list from the config file, which only contains ~550 TLDs (while DNA offers over 800), get the TLD list directly from the API.

In the second commit, I added a try-catch block and logging codes because two TLDs only have registration prices.

For future development, note that some TLDs have all yearly prices, while others only have one-year prices.